### PR TITLE
Fix float narrowing tests in locales other than en-US

### DIFF
--- a/ClearScriptTest/JScriptCoreEngineTest.cs
+++ b/ClearScriptTest/JScriptCoreEngineTest.cs
@@ -2958,9 +2958,9 @@ namespace Microsoft.ClearScript.Test
         public void JScriptCoreEngine_DisableFloatNarrowing()
         {
             engine.AddHostType("StringT", typeof(string));
-            Assert.AreEqual("123,456.80", engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
+            Assert.AreEqual(123456.80.ToString("###,###.00"), engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
             engine.DisableFloatNarrowing = true;
-            Assert.AreEqual("123,456.75", engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
+            Assert.AreEqual(123456.75.ToString("###,###.00"), engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
         }
 
         [TestMethod, TestCategory("JScriptCoreEngine")]

--- a/ClearScriptTest/JScriptEngineTest.cs
+++ b/ClearScriptTest/JScriptEngineTest.cs
@@ -3018,9 +3018,9 @@ namespace Microsoft.ClearScript.Test
         public void JScriptEngine_DisableFloatNarrowing()
         {
             engine.AddHostType("StringT", typeof(string));
-            Assert.AreEqual("123,456.80", engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
+            Assert.AreEqual(123456.80.ToString("###,###.00"), engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
             engine.DisableFloatNarrowing = true;
-            Assert.AreEqual("123,456.75", engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
+            Assert.AreEqual(123456.75.ToString("###,###.00"), engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
         }
 
         [TestMethod, TestCategory("JScriptEngine")]

--- a/ClearScriptTest/V8ScriptEngineTest.cs
+++ b/ClearScriptTest/V8ScriptEngineTest.cs
@@ -4620,9 +4620,9 @@ namespace Microsoft.ClearScript.Test
         public void V8ScriptEngine_DisableFloatNarrowing()
         {
             engine.AddHostType("StringT", typeof(string));
-            Assert.AreEqual("123,456.80", engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
+            Assert.AreEqual(123456.80.ToString("###,###.00"), engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
             engine.DisableFloatNarrowing = true;
-            Assert.AreEqual("123,456.75", engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
+            Assert.AreEqual(123456.75.ToString("###,###.00"), engine.Evaluate("StringT.Format('{0:###,###.00}', 123456.75)"));
         }
 
         [TestMethod, TestCategory("V8ScriptEngine")]

--- a/ClearScriptTest/VBScriptCoreEngineTest.cs
+++ b/ClearScriptTest/VBScriptCoreEngineTest.cs
@@ -3084,9 +3084,9 @@ namespace Microsoft.ClearScript.Test
         public void VBScriptCoreEngine_DisableFloatNarrowing()
         {
             engine.AddHostType("StringT", typeof(string));
-            Assert.AreEqual("123,456.80", engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
+            Assert.AreEqual(123456.80.ToString("###,###.00"), engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
             engine.DisableFloatNarrowing = true;
-            Assert.AreEqual("123,456.75", engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
+            Assert.AreEqual(123456.75.ToString("###,###.00"), engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
         }
 
         [TestMethod, TestCategory("VBScriptCoreEngine")]

--- a/ClearScriptTest/VBScriptEngineTest.cs
+++ b/ClearScriptTest/VBScriptEngineTest.cs
@@ -3153,9 +3153,9 @@ namespace Microsoft.ClearScript.Test
         public void VBScriptEngine_DisableFloatNarrowing()
         {
             engine.AddHostType("StringT", typeof(string));
-            Assert.AreEqual("123,456.80", engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
+            Assert.AreEqual(123456.80.ToString("###,###.00"), engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
             engine.DisableFloatNarrowing = true;
-            Assert.AreEqual("123,456.75", engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
+            Assert.AreEqual(123456.75.ToString("###,###.00"), engine.Evaluate("StringT.Format(\"{0:###,###.00}\", 123456.75)"));
         }
 
         [TestMethod, TestCategory("VBScriptEngine")]


### PR DESCRIPTION
String.Format, by default, takes into account the current locale. In these tests, the result was being compared to a constant string that uses point as the decimal separator and commas as the thousands separators. Computers set to other languages would use different symbols for this, and tests would fail.

The alternative way to fix these tests would be to supply the en-US (or invariant) culture to the script being evaluated.