### PR TITLE
Default implementation for IV8FastHostObjectOperations

### DIFF
--- a/ClearScript/V8/FastProxy/IV8FastHostObjectOperations.cs
+++ b/ClearScript/V8/FastProxy/IV8FastHostObjectOperations.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+using Microsoft.ClearScript.Util;
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.ClearScript.V8.FastProxy
@@ -15,7 +17,11 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// </summary>
         /// <param name="instance">The object for which to get a human-readable name.</param>
         /// <returns>A human-readable name for the specified object.</returns>
-        string GetFriendlyName(IV8FastHostObject instance);
+        string GetFriendlyName(IV8FastHostObject instance)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => $"FastHostObject:{GetType().GetFriendlyName()}"
+#endif
+        ;
 
         /// <summary>
         /// Gets the value of a named property.
@@ -24,7 +30,11 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="name">The name of the property to get.</param>
         /// <param name="value">On return, the value of the property if it was found.</param>
         /// <param name="isCacheable">On return, <c>true</c> if the property value is a cacheable constant, <c>false</c> otherwise.</param>
-        void GetProperty(IV8FastHostObject instance, string name, in V8FastResult value, out bool isCacheable);
+        void GetProperty(IV8FastHostObject instance, string name, in V8FastResult value, out bool isCacheable)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Named property {name} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Sets the value of a named property.
@@ -32,7 +42,11 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="instance">The object whose property to set.</param>
         /// <param name="name">The name of the property to set.</param>
         /// <param name="value">The property value.</param>
-        void SetProperty(IV8FastHostObject instance, string name, in V8FastArg value);
+        void SetProperty(IV8FastHostObject instance, string name, in V8FastArg value)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Named property {name} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Gets the attributes of a named property.
@@ -40,7 +54,11 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="instance">The object to search for the property.</param>
         /// <param name="name">The name of the property to query.</param>
         /// <returns>A set of property attributes.</returns>
-        V8FastHostPropertyFlags QueryProperty(IV8FastHostObject instance, string name);
+        V8FastHostPropertyFlags QueryProperty(IV8FastHostObject instance, string name)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Named property {name} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Deletes a named property.
@@ -48,14 +66,22 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="instance">The object whose property to delete.</param>
         /// <param name="name">The name of the property to delete.</param>
         /// <returns><c>True</c> if the property was deleted or does not exist; <c>false</c> if the property exists but is not deletable.</returns>
-        bool DeleteProperty(IV8FastHostObject instance, string name);
+        bool DeleteProperty(IV8FastHostObject instance, string name)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Named property {name} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Enumerates the names of all existing named properties.
         /// </summary>
         /// <param name="instance">The object to search for named properties.</param>
         /// <returns>A collection containing the names of all existing named properties.</returns>
-        IEnumerable<string> GetPropertyNames(IV8FastHostObject instance);
+        IEnumerable<string> GetPropertyNames(IV8FastHostObject instance)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException("Listing named properties is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Gets the value of an indexed property.
@@ -63,7 +89,11 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="instance">The object to search for the property.</param>
         /// <param name="index">The index of the property to get.</param>
         /// <param name="value">On return, the value of the property if it was found.</param>
-        void GetProperty(IV8FastHostObject instance, int index, in V8FastResult value);
+        void GetProperty(IV8FastHostObject instance, int index, in V8FastResult value)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Indexed property {index} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Sets the value of an indexed property.
@@ -71,7 +101,11 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="instance">The object whose property to set.</param>
         /// <param name="index">The index of the property to set.</param>
         /// <param name="value">The property value.</param>
-        void SetProperty(IV8FastHostObject instance, int index, in V8FastArg value);
+        void SetProperty(IV8FastHostObject instance, int index, in V8FastArg value)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Indexed property {index} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Gets the attributes of an indexed property.
@@ -79,7 +113,11 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="instance">The object to search for the property.</param>
         /// <param name="index">The index of the property to query.</param>
         /// <returns>A set of property attributes.</returns>
-        V8FastHostPropertyFlags QueryProperty(IV8FastHostObject instance, int index);
+        V8FastHostPropertyFlags QueryProperty(IV8FastHostObject instance, int index)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Indexed property {index} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Deletes an indexed property.
@@ -87,27 +125,43 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// <param name="instance">The object whose property to delete.</param>
         /// <param name="index">The index of the property to delete.</param>
         /// <returns><c>True</c> if the property was deleted or does not exist; <c>false</c> if the property exists but is not deletable.</returns>
-        bool DeleteProperty(IV8FastHostObject instance, int index);
+        bool DeleteProperty(IV8FastHostObject instance, int index)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException($"Indexed property {index} is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Enumerates the indices of all existing indexed properties.
         /// </summary>
         /// <param name="instance">The object to search for indexed properties.</param>
         /// <returns>A collection containing the indices of all existing indexed properties.</returns>
-        IEnumerable<int> GetPropertyIndices(IV8FastHostObject instance);
+        IEnumerable<int> GetPropertyIndices(IV8FastHostObject instance)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException("Listing indexed properties is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Creates a fast enumerator that iterates through the object's contents.
         /// </summary>
         /// <param name="instance">The object for which to create a fast enumerator.</param>
         /// <returns>A fast enumerator for the specified object's contents.</returns>
-        IV8FastEnumerator CreateEnumerator(IV8FastHostObject instance);
+        IV8FastEnumerator CreateEnumerator(IV8FastHostObject instance)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException("Enumerator is not implemented")
+#endif
+        ;
 
         /// <summary>
         /// Creates a fast asynchronous enumerator that iterates through the object's contents.
         /// </summary>
         /// <param name="instance">The object for which to create a fast asynchronous enumerator.</param>
         /// <returns>A fast asynchronous enumerator for the specified object's contents.</returns>
-        IV8FastAsyncEnumerator CreateAsyncEnumerator(IV8FastHostObject instance);
+        IV8FastAsyncEnumerator CreateAsyncEnumerator(IV8FastHostObject instance)
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER || UNITY_2022_3_OR_NEWER
+            => throw new NotImplementedException("Async enumerator is not implemented")
+#endif
+        ;
     }
 }


### PR DESCRIPTION
This change adds a default implementation to IV8FastHostObjectOperations on runtimes that support it. The use case is objects exported to JavaScript that are part of an inheritance hierarchy. Without the default implementation, one has to laboriously implement every interface method every time.

I find it unlikely you will just merge this, but I'm hoping for some insightful feedback.

Usage:

```Sharp
class One { }

class Two : One, IV8FastHostObject, IV8FastHostObjectOperations
{
    void Bing() { }
    
    IV8FastHostObjectOperations IV8FastHostObject.Operations => this;

    private static readonly V8FastHostMethodInvoker<Two> BING =
        static (Two self, in V8FastArgs args, in V8FastResult result) =>
            self.Bing();
    
    void IV8FastHostObjectOperations.GetProperty(IV8FastHostObject instance, string name, in V8FastResult value, out bool isCacheable) =>
        GetProperty(name, value, out isCacheable);

    protected virtual void GetProperty(string name, V8FastResult value, out bool isCacheable)
    {
        isCacheable = true;

        switch (name)
        {
            case nameof(Bing):
                value.Set(BING);
                break;
            default:
                throw new NotImplementedException(
                    $"Named property {name} is not implemented");
        }
    }
}

class Three : Two
{
    void Bong() { }
    
    private static readonly V8FastHostMethodInvoker<Three> BONG =
        static (Three self, in V8FastArgs args, in V8FastResult result) =>
            self.Bong();
    
    protected override void GetProperty(string name, V8FastResult value, out bool isCacheable)
    {
        isCacheable = true;

        switch (name)
        {
            case nameof(Bong):
                value.Set(BONG);
                break;
            default:
                base.GetProperty(name, value, out isCacheable);
                break;
        }
    }
}
```