### PR TITLE
Don't allocate if the caller to fast args does not obtain an object

### DIFF
--- a/ClearScript/V8/FastProxy/V8FastArgs.cs
+++ b/ClearScript/V8/FastProxy/V8FastArgs.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Numerics;
-using Microsoft.ClearScript.Util;
 using Microsoft.ClearScript.V8.SplitProxy;
 
 namespace Microsoft.ClearScript.V8.FastProxy
@@ -15,23 +14,13 @@ namespace Microsoft.ClearScript.V8.FastProxy
     {
         private readonly ReadOnlySpan<V8Value.FastArg> args;
         private readonly V8FastArgKind argKind;
-        private readonly object[] objects;
+        private readonly V8ScriptEngine engine;
 
         internal V8FastArgs(V8ScriptEngine engine, in ReadOnlySpan<V8Value.FastArg> args, V8FastArgKind argKind)
         {
             this.args = args;
             this.argKind = argKind;
-            objects = null;
-
-            for (var index = 0; index < args.Length; index++)
-            {
-                var tempObject = V8FastArgImpl.InitializeObject(engine, args[index]);
-                if (tempObject is not Nonexistent)
-                {
-                    EnsureObjects(ref objects, args.Length);
-                    objects[index] = tempObject;
-                }
-            }
+            this.engine = engine;
         }
 
         /// <summary>
@@ -432,18 +421,6 @@ namespace Microsoft.ClearScript.V8.FastProxy
         /// </remarks>
         public T Get<T>(int index, string name = null) => V8FastArgImpl.Get<T>(args[index], GetObject(index), argKind, name);
 
-        private static void EnsureObjects(ref object[] objects, int count)
-        {
-            if (objects is null)
-            {
-                objects = new object[count];
-                for (var index = 0; index < count; index++)
-                {
-                    objects[index] = Nonexistent.Value;
-                }
-            }
-        }
-
-        private object GetObject(int index) => (objects is not null) ? objects[index] : Nonexistent.Value;
+        private object GetObject(int index) => V8FastArgImpl.InitializeObject(engine, args[index]);
     }
 }


### PR DESCRIPTION
Currently, when there are any objects in the argument list, V8FastArgs allocates managed heap memory even if they are never accessed. Also, any additional API to access V8 objects in a non-allocating way depends on this change.

I argue that preemptively allocating objects and caching them in an array only makes sense if you expect the caller to call V8FastArgs.Get<T> on the same argument many times. But that case does not exist. A caller who uses FastProxy cares about performance and can be expected to call V8FastArgs.Get<T> only once and store the result in a local variable for reuse.

My goal is to have zero unsolicited allocations when responding to calls from JavaScript through V8FastArgs. If this pull request is not to your liking, tell me what you would accept, and I'll try to make that.